### PR TITLE
Cargar claves de Supabase desde variables de entorno

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://tu-proyecto.supabase.co
+VITE_SUPABASE_ANON_KEY=tu_clave_anonima

--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -2,9 +2,8 @@
 
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = "https://bdgwljmmmiprpbonpshr.supabase.co";
-const supabaseAnonKey =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJkZ3dsam1tbWlwcnBib25wc2hyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkxNTAzNzIsImV4cCI6MjA2NDcyNjM3Mn0.IQ7YjdyEacwCILUJa5JvwrTeN_3MA-4B49djHYPpMiE";
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
  


### PR DESCRIPTION
## Summary
- lee las credenciales de Supabase desde `import.meta.env`
- proporciona un archivo `.env.example` con los nombres de las variables

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844788d9b74832099dbf0a26feeae51